### PR TITLE
Random rocks

### DIFF
--- a/entities/Asteroid.tscn
+++ b/entities/Asteroid.tscn
@@ -11,10 +11,3 @@ physics_material_override = SubResource( 1 )
 linear_damp = 0.0
 angular_damp = 0.0
 script = ExtResource( 1 )
-
-[node name="Polygon2D" type="Polygon2D" parent="."]
-color = Color( 0.372549, 0.341176, 0.309804, 1 )
-polygon = PoolVector2Array( 16, -64, 48, -48, 40, -24, 48, -16, 56, 0, 56, 16, 64, 32, 56, 56, 32, 48, 16, 64, -24, 56, -56, 64, -64, 40, -48, 8, -64, -24, -56, -56, -24, -48, 0, -56 )
-
-[node name="CollisionShape2D" type="CollisionPolygon2D" parent="."]
-polygon = PoolVector2Array( 16, -64, 48, -48, 40, -24, 48, -16, 56, 0, 56, 16, 64, 32, 56, 56, 32, 48, 16, 64, -24, 56, -56, 64, -64, 40, -48, 8, -64, -24, -56, -56, -24, -48, 0, -56 )

--- a/entities/asteroid.gd
+++ b/entities/asteroid.gd
@@ -3,13 +3,14 @@ extends RigidBody2D
 
 var hp: int = 10
 
-func _ready() -> void:
-	var start_impulse: Vector2 = (Vector2.ZERO - get_global_position())*randf()
-	apply_central_impulse(start_impulse)
-
+func _init() -> void:
 	var outline = create_outline()
 	set_collision_shape(outline)
 	set_drawn_shape(outline)
+
+func _ready() -> void:
+	var start_impulse: Vector2 = (Vector2.ZERO - get_global_position())*randf()
+	apply_central_impulse(start_impulse)
 
 # Generate a random shape for a new asteroid
 func create_outline() -> PoolVector2Array:

--- a/entities/asteroid.gd
+++ b/entities/asteroid.gd
@@ -3,17 +3,52 @@ extends RigidBody2D
 
 var hp: int = 10
 
+func create_outline() -> PoolVector2Array:
+	return PoolVector2Array([
+		Vector2(16, -64),
+		Vector2(48, -48),
+		Vector2(40, -24),
+		Vector2(48, -16),
+		Vector2(56, 0),
+		Vector2(56, 16),
+		Vector2(64, 32),
+		Vector2(56, 56),
+		Vector2(32, 48),
+		Vector2(16, 64),
+		Vector2(-24, 56),
+		Vector2(-56, 64),
+		Vector2(-64, 40),
+		Vector2(-48, 8),
+		Vector2(-64, -24),
+		Vector2(-56, -56),
+		Vector2(-24, -48),
+		Vector2(0, -56)
+	])
+
+func set_collision_shape(outline: PoolVector2Array) -> void:
+	var owner: int = create_shape_owner(self)
+	var shape = ConcavePolygonShape2D.new()
+	shape.set_segments(outline)
+	shape_owner_add_shape(owner, shape)
 
 func _ready() -> void:
 	var start_impulse: Vector2 = (Vector2.ZERO - get_global_position())*randf()
 	apply_central_impulse(start_impulse)
 
+	var outline = create_outline()
+	set_collision_shape(outline)
+	set_drawn_shape(outline)
+
+func set_drawn_shape(outline: PoolVector2Array) -> void:
+	var polygon = Polygon2D.new()
+	polygon.set_polygon(outline)
+	polygon.set_color(Color(0.372549, 0.341176, 0.309804, 1))
+	add_child(polygon)
+
 
 func take_damage(value: int = 1) -> void:
 	hp -= value
-	
+
 	if hp <= 0:
 		EventBus.emit_signal("asteroid_destroyed", 10)
 		queue_free()
-	else:
-		pass

--- a/entities/asteroid.gd
+++ b/entities/asteroid.gd
@@ -1,5 +1,8 @@
 extends RigidBody2D
 
+const DIRECTION_RANGE = PI / 4
+const MIN_SPEED = 200
+const MAX_SPEED = 600
 
 var hp: int = 10
 
@@ -9,7 +12,11 @@ func _init() -> void:
 	set_drawn_shape(outline)
 
 func _ready() -> void:
-	var start_impulse: Vector2 = (Vector2.ZERO - get_global_position())*randf()
+	var start_impulse: Vector2 = \
+		(Vector2.ZERO - get_global_position()) \
+			.normalized() \
+			.rotated(DIRECTION_RANGE * 2 * randf() - DIRECTION_RANGE) \
+			* (MIN_SPEED + (MAX_SPEED - MIN_SPEED) * randf())
 	apply_central_impulse(start_impulse)
 
 # Generate a random shape for a new asteroid


### PR DESCRIPTION
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/1450065/212571038-35da3af7-36fd-4129-9e6d-db93bdcf4ec9.png">

Implements the first point from issue #1, "random shape when added to the scene tree". I guess there is more to be done before the issue can be closed but it seemed like a good moment to get feedback.

First, let me know if the shapes being produced look ok to you. The gist of the algorithm is "draw a circle, but badly". There are a few parameters that can be tweaked, or we could try something different entirely.

You might have a better idea than I do whether I'm doing things properly. It seems like there's no other way to make the asteroid shape dynamic than to generate it in the script, but removing the CollisionPolygon2D from the scene produces this warning:

<img width="560" alt="image" src="https://user-images.githubusercontent.com/1450065/212571485-17d9c8db-2ad3-4347-b5b8-2beccd3756b6.png">

Not sure how to make the IDE happy here. Do we even need an asteroid "scene"? If we make asteroid mass dynamic based on size then it looks like there's not much else left for the `.tscn` file to do. But maybe that's just how you define a class in Godot.

I'm also not sure if the `_ready` hook is even the right place to be doing this sort of setup. Do you know if there's something more like an object constructor that I should be using instead?